### PR TITLE
Code Completion for resource bundle keys for Liferay Taglibs (#59)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ formatSource {
 }
 
 intellij {
-	plugins 'gradle', 'maven', 'terminal', 'JavaEE'
+	plugins 'gradle', 'maven', 'terminal', 'JavaEE', 'java-i18n'
 	version "IU-2018.1.4"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ formatSource {
 }
 
 intellij {
-	plugins 'gradle', 'maven', 'terminal', 'JavaEE', 'java-i18n'
+	plugins 'gradle', 'maven', 'terminal', 'JavaEE', 'java-i18n', 'properties'
 	version "IU-2018.1.4"
 }
 

--- a/src/main/java/com/liferay/ide/idea/language/tag/LiferayTaglibResourceBundlePropertyReference.java
+++ b/src/main/java/com/liferay/ide/idea/language/tag/LiferayTaglibResourceBundlePropertyReference.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.idea.language.tag;
+
+import com.intellij.lang.properties.IProperty;
+import com.intellij.lang.properties.psi.PropertiesFile;
+import com.intellij.lang.properties.references.PropertyReference;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.ResolveResult;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @author Dominik Marks
+ */
+public class LiferayTaglibResourceBundlePropertyReference extends PropertyReference {
+
+	public LiferayTaglibResourceBundlePropertyReference(
+		@NotNull String key, @NotNull PsiElement element, @Nullable String bundleName, boolean soft) {
+
+		super(key, element, bundleName, soft);
+	}
+
+	@NotNull
+	@Override
+	public ResolveResult[] multiResolve(boolean incompleteCode) {
+		ResolveResult[] resolveResults = super.multiResolve(incompleteCode);
+
+		Stream<ResolveResult> stream = Arrays.stream(resolveResults);
+
+		return stream.filter(
+			element -> {
+				if (element instanceof PsiElementResolveResult) {
+					PsiElementResolveResult psiElementResolveResult = (PsiElementResolveResult)element;
+
+					PsiElement psiElement = psiElementResolveResult.getElement();
+
+					if (psiElement instanceof IProperty) {
+						IProperty property = (IProperty)psiElement;
+
+						PropertiesFile propertiesFile = property.getPropertiesFile();
+
+						//only resolve properties from Language files
+						return _isLanguageFile(propertiesFile);
+					}
+				}
+
+				return false;
+			}).toArray(ResolveResult[]::new);
+	}
+
+	@Override
+	protected void addKey(Object propertyObject, Set<Object> variants) {
+		if (propertyObject instanceof IProperty) {
+			IProperty property = (IProperty)propertyObject;
+
+			PropertiesFile propertiesFile = property.getPropertiesFile();
+
+			if (_isLanguageFile(propertiesFile)) {
+				//only add properties from Language files during code completion
+				super.addKey(propertyObject, variants);
+			}
+		}
+	}
+
+	private static boolean _isLanguageFile(PropertiesFile propertiesFile) {
+		if (propertiesFile != null) {
+			String name = propertiesFile.getName();
+
+			if (name != null) {
+				return name.startsWith("Language");
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/src/main/java/com/liferay/ide/idea/language/tag/LiferayTaglibResourceBundleReferenceContributor.java
+++ b/src/main/java/com/liferay/ide/idea/language/tag/LiferayTaglibResourceBundleReferenceContributor.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.idea.language.tag;
+
+import com.intellij.lang.properties.PropertiesReferenceProvider;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReferenceContributor;
+import com.intellij.psi.PsiReferenceRegistrar;
+import com.intellij.psi.filters.ElementFilter;
+import com.intellij.psi.xml.XmlAttribute;
+import com.intellij.psi.xml.XmlTag;
+import com.intellij.xml.util.XmlUtil;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Adds code completion features for references to language keys inside Liferay or AlloyUI Taglibs
+ *
+ * @author Dominik Marks
+ */
+public class LiferayTaglibResourceBundleReferenceContributor extends PsiReferenceContributor {
+
+	@Override
+	public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
+		Set<String> attributeNames = new HashSet<>();
+
+		_taglibAttributes.forEach(
+			(key, value) -> {
+				Stream<SimpleImmutableEntry<String, String>> stream = value.stream();
+
+				stream.map(SimpleImmutableEntry::getValue).forEach(attributeNames::add);
+			});
+
+		XmlUtil.registerXmlAttributeValueReferenceProvider(
+			registrar, attributeNames.toArray(new String[attributeNames.size()]), new LiferayTaglibFilter(), true,
+			new PropertiesReferenceProvider(true));
+	}
+
+	private static Map<String, Collection<SimpleImmutableEntry<String, String>>> _taglibAttributes = new HashMap<>();
+
+	static {
+		_taglibAttributes.put(
+			LiferayTaglibs.TAGLIB_URI_LIFERAY_UI,
+			Arrays.asList(
+				new SimpleImmutableEntry<>("app-view-search-entry", "containerType"),
+				new SimpleImmutableEntry<>("alert", "message"),
+				new SimpleImmutableEntry<>("asset-addon-entry-selector", "title"),
+				new SimpleImmutableEntry<>("asset-metadata", "metadataField"),
+				new SimpleImmutableEntry<>("asset-tags-summary", "message"),
+				new SimpleImmutableEntry<>("custom-attribute", "name"),
+				new SimpleImmutableEntry<>("diff-html", "infoMessage"),
+				new SimpleImmutableEntry<>("drop-here-info", "message"),
+				new SimpleImmutableEntry<>("empty-result-message", "message"),
+				new SimpleImmutableEntry<>("error", "message"),
+				new SimpleImmutableEntry<>("form-navigator", "categoryLabels"),
+				new SimpleImmutableEntry<>("form-navigator", "categorySectionLabels"),
+				new SimpleImmutableEntry<>("header", "backLabel"), new SimpleImmutableEntry<>("header", "title"),
+				new SimpleImmutableEntry<>("icon", "message"),
+				new SimpleImmutableEntry<>("icon-delete", "confirmation"),
+				new SimpleImmutableEntry<>("icon-delete", "message"),
+				new SimpleImmutableEntry<>("icon-help", "message"), new SimpleImmutableEntry<>("icon-menu", "message"),
+				new SimpleImmutableEntry<>("input-field", "placeholder"),
+				new SimpleImmutableEntry<>("input-localized", "helpMessaage"),
+				new SimpleImmutableEntry<>("input-localized", "placeholder"),
+				new SimpleImmutableEntry<>("input-resource", "title"),
+				new SimpleImmutableEntry<>("input-move-boxes", "leftTitle"),
+				new SimpleImmutableEntry<>("input-move-boxes", "rightTitle"),
+				new SimpleImmutableEntry<>("input-resource", "title"), new SimpleImmutableEntry<>("message", "key"),
+				new SimpleImmutableEntry<>("panel", "helpMessage"), new SimpleImmutableEntry<>("panel", "title"),
+				new SimpleImmutableEntry<>("progress", "message"),
+				new SimpleImmutableEntry<>("quick-access-entry", "label"),
+				new SimpleImmutableEntry<>("search-container", "emptyResultsMessage"),
+				new SimpleImmutableEntry<>("search-container", "headerNames"),
+				new SimpleImmutableEntry<>("search-container-column-button", "name"),
+				new SimpleImmutableEntry<>("search-container-column-date", "name"),
+				new SimpleImmutableEntry<>("search-container-column-text", "name"),
+				new SimpleImmutableEntry<>("search-toggle", "buttonLabel"),
+				new SimpleImmutableEntry<>("success", "message"), new SimpleImmutableEntry<>("tabs", "names"),
+				new SimpleImmutableEntry<>("upload-progress", "message")));
+
+		_taglibAttributes.put(
+			LiferayTaglibs.TAGLIB_URI_LIFERAY_AUI,
+			Arrays.asList(
+				new SimpleImmutableEntry<>("a", "title"), new SimpleImmutableEntry<>("a", "label"),
+				new SimpleImmutableEntry<>("button", "value"),
+				new SimpleImmutableEntry<>("field-wrapper", "helpMessage"),
+				new SimpleImmutableEntry<>("field-wrapper", "label"),
+				new SimpleImmutableEntry<>("fieldset", "helpMessage"), new SimpleImmutableEntry<>("fieldset", "label"),
+				new SimpleImmutableEntry<>("icon", "label"), new SimpleImmutableEntry<>("input", "helpMessage"),
+				new SimpleImmutableEntry<>("input", "label"), new SimpleImmutableEntry<>("input", "labelOff"),
+				new SimpleImmutableEntry<>("input", "labelOn"), new SimpleImmutableEntry<>("input", "title"),
+				new SimpleImmutableEntry<>("input", "placeholder"), new SimpleImmutableEntry<>("input", "prefix"),
+				new SimpleImmutableEntry<>("input", "suffix"),
+				new SimpleImmutableEntry<>("nav-bar", "selectedItemName"),
+				new SimpleImmutableEntry<>("nav-item", "label"), new SimpleImmutableEntry<>("nav-item", "title"),
+				new SimpleImmutableEntry<>("option", "label"), new SimpleImmutableEntry<>("panel", "label"),
+				new SimpleImmutableEntry<>("select", "label"), new SimpleImmutableEntry<>("select", "helpMessage"),
+				new SimpleImmutableEntry<>("select", "prefix"), new SimpleImmutableEntry<>("select", "suffix"),
+				new SimpleImmutableEntry<>("select", "title"), new SimpleImmutableEntry<>("validator", "errorMessage"),
+				new SimpleImmutableEntry<>("workflow-status", "helpMessage"),
+				new SimpleImmutableEntry<>("workflow-status", "statusMessage")));
+
+		_taglibAttributes.put(
+			LiferayTaglibs.TAGLIB_URI_LIFERAY_AUI_OLD, _taglibAttributes.get(LiferayTaglibs.TAGLIB_URI_LIFERAY_AUI));
+
+		_taglibAttributes.put(
+			LiferayTaglibs.TAGLIB_URI_LIFERAY_ASSET,
+			Arrays.asList(
+				new SimpleImmutableEntry<>("asset-addon-entry-selector", "title"),
+				new SimpleImmutableEntry<>("asset-metadata", "metadataField"),
+				new SimpleImmutableEntry<>("asset-tags-summary", "message")));
+
+		_taglibAttributes.put(
+			LiferayTaglibs.TAGLIB_URI_LIFERAY_EXPANDO,
+			Arrays.asList(new SimpleImmutableEntry<>("custom-attribute", "name")));
+
+		_taglibAttributes.put(
+			LiferayTaglibs.TAGLIB_URI_LIFERAY_FRONTEND,
+			Arrays.asList(
+				new SimpleImmutableEntry<>("email-notification-settings", "bodyLabel"),
+				new SimpleImmutableEntry<>("email-notification-settings", "helpMessage"),
+				new SimpleImmutableEntry<>("management-bar-button", "label"),
+				new SimpleImmutableEntry<>("management-bar-filter", "label")));
+
+		_taglibAttributes.put(
+			LiferayTaglibs.TAGLIB_URI_LIFERAY_TRASH,
+			Arrays.asList(
+				new SimpleImmutableEntry<>("empty", "confirmMessage"),
+				new SimpleImmutableEntry<>("empty", "emptyMessage"),
+				new SimpleImmutableEntry<>("empty", "infoMessage")));
+	}
+
+	private class LiferayTaglibFilter implements ElementFilter {
+
+		public boolean isAcceptable(Object element, PsiElement context) {
+			PsiElement psiElement = (PsiElement)element;
+
+			PsiElement parent = psiElement.getParent();
+
+			if (parent instanceof XmlAttribute) {
+				XmlAttribute xmlAttribute = (XmlAttribute)parent;
+
+				XmlTag xmlTag = xmlAttribute.getParent();
+
+				if (xmlTag != null) {
+					String namespace = xmlTag.getNamespace();
+
+					if (_taglibAttributes.containsKey(namespace)) {
+						String tagLocalName = xmlTag.getLocalName();
+						String attributeLocalName = xmlAttribute.getLocalName();
+						Collection<SimpleImmutableEntry<String, String>> entries = _taglibAttributes.get(namespace);
+
+						Stream<SimpleImmutableEntry<String, String>> stream = entries.stream();
+
+						if (stream.anyMatch(entry -> entry.getKey().equals(tagLocalName) &&
+							 entry.getValue().equals(attributeLocalName))) {
+
+							return true;
+						}
+
+						return false;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		public boolean isClassAcceptable(Class hintClass) {
+			return true;
+		}
+
+	}
+
+}

--- a/src/main/java/com/liferay/ide/idea/language/tag/LiferayTaglibResourceBundleReferenceContributor.java
+++ b/src/main/java/com/liferay/ide/idea/language/tag/LiferayTaglibResourceBundleReferenceContributor.java
@@ -14,7 +14,6 @@
 
 package com.liferay.ide.idea.language.tag;
 
-import com.intellij.lang.properties.PropertiesReferenceProvider;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReferenceContributor;
 import com.intellij.psi.PsiReferenceRegistrar;
@@ -54,7 +53,7 @@ public class LiferayTaglibResourceBundleReferenceContributor extends PsiReferenc
 
 		XmlUtil.registerXmlAttributeValueReferenceProvider(
 			registrar, attributeNames.toArray(new String[attributeNames.size()]), new LiferayTaglibFilter(), true,
-			new PropertiesReferenceProvider(true));
+			new LiferayTaglibResourceBundleReferenceProvider(true));
 	}
 
 	private static Map<String, Collection<SimpleImmutableEntry<String, String>>> _taglibAttributes = new HashMap<>();

--- a/src/main/java/com/liferay/ide/idea/language/tag/LiferayTaglibResourceBundleReferenceProvider.java
+++ b/src/main/java/com/liferay/ide/idea/language/tag/LiferayTaglibResourceBundleReferenceProvider.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.idea.language.tag;
+
+import com.intellij.lang.properties.PropertiesReferenceProvider;
+import com.intellij.lang.properties.references.PropertyReference;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.util.ProcessingContext;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author Dominik Marks
+ */
+public class LiferayTaglibResourceBundleReferenceProvider extends PropertiesReferenceProvider {
+
+	public LiferayTaglibResourceBundleReferenceProvider(boolean defaultSoft) {
+		super(defaultSoft);
+	}
+
+	@NotNull
+	@Override
+	public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+		PsiReference[] referencesByElement = super.getReferencesByElement(element, context);
+
+		if (referencesByElement.length == 1) {
+			PsiReference psiReference = referencesByElement[0];
+
+			if (psiReference instanceof PropertyReference) {
+				PropertyReference propertyReference = (PropertyReference)psiReference;
+
+				String canonicalText = propertyReference.getCanonicalText();
+				PsiElement psiElement = propertyReference.getElement();
+				boolean soft = propertyReference.isSoft();
+
+				return new PsiReference[] {
+					new LiferayTaglibResourceBundlePropertyReference(canonicalText, psiElement, null, soft)
+				};
+			}
+		}
+
+		return referencesByElement;
+	}
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -117,5 +117,6 @@
 		<psi.referenceContributor implementation="com.liferay.ide.idea.language.LiferayXmlFileReferenceContributor"/>
 		<completion.contributor order="first" language="JAVA" implementationClass="com.liferay.ide.idea.language.osgi.ComponentPropertiesCompletionContributor"/>
 		<completion.contributor order="first" language="XML" implementationClass="com.liferay.ide.idea.language.tag.AuiTagAttributeValueCompletionContributor"/>
+		<psi.referenceContributor implementation="com.liferay.ide.idea.language.tag.LiferayTaglibResourceBundleReferenceContributor"/>
 	</extensions>
 </idea-plugin>


### PR DESCRIPTION
I would like to contribute a ReferenceContributor for resource bundle keys in Liferay Taglibs. Many attributes can refer to keys inside the language files.

IntelliJ will suggest keys from available Language_XX.properties files for attributes like <liferay-ui:message key="..." />. It is possible to search for usage of those keys (Alt-F7) and to rename the keys on the fly (Shift-F6).