### PR TITLE
INTELLIJ-3 disable to index the bundles folder in Liferay workspace project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 *.iml
 out/
 /bin/
+!/src/main/java/com/liferay/ide/idea/language/gradle

--- a/src/main/java/com/liferay/ide/idea/language/gradle/LiferayWorkspaceGradleProjectResolver.java
+++ b/src/main/java/com/liferay/ide/idea/language/gradle/LiferayWorkspaceGradleProjectResolver.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.idea.language.gradle;
+
+import com.intellij.openapi.externalSystem.model.DataNode;
+import com.intellij.openapi.externalSystem.model.project.ModuleData;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtil;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectUtil;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.ModuleRootModificationUtil;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+
+import java.io.File;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import org.gradle.tooling.model.DomainObjectSet;
+import org.gradle.tooling.model.idea.IdeaContentRoot;
+import org.gradle.tooling.model.idea.IdeaModule;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.gradle.service.project.AbstractProjectResolverExtension;
+
+/**
+ * @author Dominik Marks
+ */
+public class LiferayWorkspaceGradleProjectResolver extends AbstractProjectResolverExtension {
+
+	@NotNull
+	@Override
+	public Set<Class> getExtraProjectModelClasses() {
+		return Collections.<Class>singleton(LiferayWorkspaceGradleTaskModel.class);
+	}
+
+	@NotNull
+	@Override
+	public Set<Class> getToolingExtensionsClasses() {
+		return Collections.<Class>singleton(LiferayWorkspaceSupportGradleTaskModelBuilder.class);
+	}
+
+	@Override
+	public void populateModuleExtraModels(@NotNull IdeaModule gradleModule, @NotNull DataNode<ModuleData> ideModule) {
+		LiferayWorkspaceGradleTaskModel liferayWorkspaceGradleTaskModel = resolverCtx.getExtraProject(
+			gradleModule, LiferayWorkspaceGradleTaskModel.class);
+
+		if (liferayWorkspaceGradleTaskModel != null) {
+
+			// try to find the corresponding IDEA module for the Gradle Module
+
+			DomainObjectSet<? extends IdeaContentRoot> contentRoots = gradleModule.getContentRoots();
+
+			IdeaContentRoot contentRoot = contentRoots.getAt(0);
+
+			File rootDirectory = contentRoot.getRootDirectory();
+
+			VirtualFile fileByIoFile = VfsUtil.findFileByIoFile(rootDirectory, false);
+
+			if (fileByIoFile != null) {
+				Project project = ProjectUtil.guessProjectForFile(fileByIoFile);
+
+				Module module = ModuleUtil.findModuleForFile(fileByIoFile, project);
+
+				String liferayHome = liferayWorkspaceGradleTaskModel.getLiferayHome();
+
+				if (liferayHome != null) {
+					LocalFileSystem localFileSystem = LocalFileSystem.getInstance();
+
+					VirtualFile virtualFile = localFileSystem.findFileByPath(liferayHome);
+
+					if (virtualFile != null) {
+						String url = virtualFile.getUrl();
+
+						Collection<String> excludeFolders = new ArrayList<>();
+
+						excludeFolders.add(url);
+
+						ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
+
+						for (VirtualFile sourceRoot : moduleRootManager.getContentRoots()) {
+							ModuleRootModificationUtil.updateExcludedFolders(
+								module, sourceRoot, Collections.<String>emptyList(), excludeFolders);
+						}
+					}
+				}
+			}
+		}
+
+		super.populateModuleExtraModels(gradleModule, ideModule);
+	}
+
+}

--- a/src/main/java/com/liferay/ide/idea/language/gradle/LiferayWorkspaceGradleTaskModel.java
+++ b/src/main/java/com/liferay/ide/idea/language/gradle/LiferayWorkspaceGradleTaskModel.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.idea.language.gradle;
+
+import java.io.Serializable;
+
+/**
+ * @author Dominik Marks
+ */
+public interface LiferayWorkspaceGradleTaskModel extends Serializable {
+
+	/**
+	 * Returns the liferayHome directory (extracted from the Liferay Workspace plugin)
+	 *
+	 * @return
+	 */
+	public String getLiferayHome();
+
+}

--- a/src/main/java/com/liferay/ide/idea/language/gradle/LiferayWorkspaceGradleTaskModelImpl.java
+++ b/src/main/java/com/liferay/ide/idea/language/gradle/LiferayWorkspaceGradleTaskModelImpl.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.idea.language.gradle;
+
+/**
+ * @author Dominik Marks
+ */
+public class LiferayWorkspaceGradleTaskModelImpl implements LiferayWorkspaceGradleTaskModel {
+
+	@Override
+	public String getLiferayHome() {
+		return _liferayHome;
+	}
+
+	public void setLiferayHome(String liferayHome) {
+		_liferayHome = liferayHome;
+	}
+
+	private String _liferayHome;
+
+}

--- a/src/main/java/com/liferay/ide/idea/language/gradle/LiferayWorkspaceSupportGradleTaskModelBuilder.java
+++ b/src/main/java/com/liferay/ide/idea/language/gradle/LiferayWorkspaceSupportGradleTaskModelBuilder.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.idea.language.gradle;
+
+import java.io.File;
+
+import java.lang.reflect.Method;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.gradle.tooling.ErrorMessageBuilder;
+import org.jetbrains.plugins.gradle.tooling.ModelBuilderService;
+
+/**
+ * @author Dominik Marks
+ *
+ * Class to extract information from the Liferay Workspace gradle plugin
+ */
+public class LiferayWorkspaceSupportGradleTaskModelBuilder implements ModelBuilderService {
+
+	public LiferayWorkspaceSupportGradleTaskModelBuilder() {
+	}
+
+	@Override
+	public Object buildAll(String modelName, Project project) {
+		LiferayWorkspaceGradleTaskModelImpl liferayWorkspaceGradleTaskModel = new LiferayWorkspaceGradleTaskModelImpl();
+
+		Map<Project, Set<Task>> allTasks = project.getAllTasks(false);
+
+		for (Map.Entry<Project, Set<Task>> tasks : allTasks.entrySet()) {
+			for (Task task : tasks.getValue()) {
+				String taskName = task.getName();
+
+				if (taskName.equals("initBundle")) {
+					try {
+
+						//get getDestinationDir of CopyTask via reflection
+						Class<? extends Task> taskClass = task.getClass();
+
+						Method getDestinationDir = taskClass.getDeclaredMethod("getDestinationDir");
+
+						File destinationDir = (File)getDestinationDir.invoke(task);
+
+						String path = "bundles";
+
+						if (destinationDir != null) {
+							path = destinationDir.getPath();
+						}
+
+						liferayWorkspaceGradleTaskModel.setLiferayHome(path);
+					}
+					catch (Exception e) {
+						//ignore
+					}
+				}
+			}
+		}
+
+		return liferayWorkspaceGradleTaskModel;
+	}
+
+	@Override
+	public boolean canBuild(String modelName) {
+		String liferayWorkspaceGradleTaskModelClassName = LiferayWorkspaceGradleTaskModel.class.getName();
+
+		return liferayWorkspaceGradleTaskModelClassName.equals(modelName);
+	}
+
+	@NotNull
+	@Override
+	public ErrorMessageBuilder getErrorMessageBuilder(@NotNull Project project, @NotNull Exception e) {
+		ErrorMessageBuilder gradleImportError = ErrorMessageBuilder.create(project, e, "Gradle import error");
+
+		return gradleImportError.withDescription("Unable to import Liferay Workspace configuration");
+	}
+
+}

--- a/src/main/java/com/liferay/ide/idea/language/maven/LiferayBundleSupportMavenImporter.java
+++ b/src/main/java/com/liferay/ide/idea/language/maven/LiferayBundleSupportMavenImporter.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.idea.language.maven;
+
+import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider;
+import com.intellij.openapi.module.Module;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.jdom.Element;
+
+import org.jetbrains.idea.maven.importing.MavenImporter;
+import org.jetbrains.idea.maven.importing.MavenRootModelAdapter;
+import org.jetbrains.idea.maven.model.MavenId;
+import org.jetbrains.idea.maven.model.MavenPlugin;
+import org.jetbrains.idea.maven.project.MavenProject;
+import org.jetbrains.idea.maven.project.MavenProjectChanges;
+import org.jetbrains.idea.maven.project.MavenProjectsProcessorTask;
+import org.jetbrains.idea.maven.project.MavenProjectsTree;
+import org.jetbrains.idea.maven.project.SupportedRequestType;
+
+/**
+ * @author Dominik Marks
+ *
+ * A Maven Importer which resolves the Liferay Home directory if the bundle-support plugin is present and will "exclude" the bundles folder from indexing in IntelliJ IDEA
+ */
+public class LiferayBundleSupportMavenImporter extends MavenImporter {
+
+	public LiferayBundleSupportMavenImporter() {
+		super(_LIFERAY_BUNDLE_SUPPORT_MAVEN_GROUP_ID, _LIFERAY_BUNDLE_SUPPORT_MAVEN_ARTIFACT_ID);
+	}
+
+	@Override
+	public void getSupportedDependencyTypes(Collection<String> result, SupportedRequestType type) {
+		getSupportedPackagings(result);
+	}
+
+	@Override
+	public void getSupportedPackagings(Collection<String> result) {
+		result.add("pom");
+	}
+
+	@Override
+	public boolean isApplicable(MavenProject mavenProject) {
+		if (super.isApplicable(mavenProject) && _isRootProject(mavenProject)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public void preProcess(
+		Module module, MavenProject mavenProject, MavenProjectChanges mavenProjectChanges,
+		IdeModifiableModelsProvider ideModifiableModelsProvider) {
+	}
+
+	@Override
+	public void process(
+		IdeModifiableModelsProvider ideModifiableModelsProvider, Module module,
+		MavenRootModelAdapter mavenRootModelAdapter, MavenProjectsTree mavenProjectsTree, MavenProject mavenProject,
+		MavenProjectChanges mavenProjectChanges, Map<MavenProject, String> map, List<MavenProjectsProcessorTask> list) {
+
+		MavenPlugin plugin = mavenProject.findPlugin(myPluginGroupID, myPluginArtifactID);
+
+		if (plugin != null) {
+			String liferayHome = "bundles";
+
+			Element configurationElement = plugin.getConfigurationElement();
+
+			if (configurationElement != null) {
+				Element configBundleSupportLiferayHome = configurationElement.getChild(
+					_CONFIG_BUNDLE_SUPPORT_LIFERAY_HOME);
+
+				if (configBundleSupportLiferayHome != null) {
+					liferayHome = configBundleSupportLiferayHome.getText();
+				}
+			}
+
+			if (liferayHome == null) {
+				Properties properties = mavenProject.getProperties();
+
+				liferayHome = properties.getProperty(_PROPERTY_BUNDLE_SUPPORT_LIFERAY_HOME);
+			}
+
+			if (liferayHome != null) {
+				if (!(liferayHome.startsWith("/") || liferayHome.contains(":"))) {
+					mavenRootModelAdapter.addExcludedFolder(liferayHome);
+				}
+			}
+		}
+	}
+
+	private boolean _isRootProject(MavenProject mavenProject) {
+		MavenId parentId = mavenProject.getParentId();
+
+		if ((parentId == null) || (parentId.getGroupId() == null)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final String _CONFIG_BUNDLE_SUPPORT_LIFERAY_HOME = "liferayHome";
+
+	private static final String _LIFERAY_BUNDLE_SUPPORT_MAVEN_ARTIFACT_ID = "com.liferay.portal.tools.bundle.support";
+
+	private static final String _LIFERAY_BUNDLE_SUPPORT_MAVEN_GROUP_ID = "com.liferay";
+
+	private static final String _PROPERTY_BUNDLE_SUPPORT_LIFERAY_HOME = "liferayHome";
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -139,4 +139,9 @@
 		<projectViewNodeDecorator implementation="com.liferay.ide.idea.ui.decorator.ProjectViewWatchDecorator"/>
 		<implicitUsageProvider order="last" implementation="com.liferay.ide.idea.language.osgi.LiferayOsgiImplicitUsageProvider" />
 	</extensions>
+
+	<extensions defaultExtensionNs="org.jetbrains.idea.maven">
+		<importer implementation="com.liferay.ide.idea.language.maven.LiferayBundleSupportMavenImporter" />
+	</extensions>
+
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -144,4 +144,9 @@
 		<importer implementation="com.liferay.ide.idea.language.maven.LiferayBundleSupportMavenImporter" />
 	</extensions>
 
+	<extensions defaultExtensionNs="org.jetbrains.plugins.gradle">
+		<projectResolve implementation="com.liferay.ide.idea.language.gradle.LiferayWorkspaceGradleProjectResolver" />
+	</extensions>
+
+
 </idea-plugin>

--- a/src/main/resources/META-INF/services/org.jetbrains.plugins.gradle.tooling.ModelBuilderService
+++ b/src/main/resources/META-INF/services/org.jetbrains.plugins.gradle.tooling.ModelBuilderService
@@ -1,0 +1,1 @@
+com.liferay.ide.idea.language.gradle.LiferayWorkspaceSupportGradleTaskModelBuilder


### PR DESCRIPTION
Hey @jtydhr88,

here is my idea to solve the Ticket INTELLIJ-3. I wrote importers for Maven and Gradle which read the configuration of the bundle-support plugin (Maven) or the initBundle task (Gradle). It reads the configuration to find out the "bundles" directory. Per default it is "bundles" in the project root directory, but developers may configure a different directory.

As soon as IntelliJ imports the project it will exclude the "bundles" directory from indexing. To "import" the project the developer either needs to click on the "reload" icon in the Maven or Gradle tool window or the developer has to enable "auto-import" (which is a good idea anyway).

What do you think?